### PR TITLE
Change configuration format to kdl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,6 +76,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -92,6 +98,12 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chumsky"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d02796e4586c6c41aeb68eae9bfb4558a522c35f1430c14b40136c3706e09e4"
 
 [[package]]
 name = "clap"
@@ -172,9 +184,10 @@ dependencies = [
  "clap",
  "env_logger",
  "input",
+ "knuffel",
  "libc",
  "log",
- "miette",
+ "miette 5.5.0",
  "nix",
  "regex",
  "serde",
@@ -294,6 +307,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
+name = "knuffel"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f9f7a07459e9dc5d07f5dabfc2c2a965bf39195451eb785b61460c65f386eef"
+dependencies = [
+ "base64",
+ "chumsky",
+ "knuffel-derive",
+ "miette 4.7.1",
+ "thiserror",
+ "unicode-width",
+]
+
+[[package]]
+name = "knuffel-derive"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbcbdb0b6f26a4e5ecb0dd9074a430398a41b2c1624c205bcc202541ddc15488"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "lexpr"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -364,13 +404,25 @@ dependencies = [
 
 [[package]]
 name = "miette"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c90329e44f9208b55f45711f9558cec15d7ef8295cc65ecd6d4188ae8edc58c"
+dependencies = [
+ "miette-derive 4.7.1",
+ "once_cell",
+ "thiserror",
+ "unicode-width",
+]
+
+[[package]]
+name = "miette"
 version = "5.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4afd9b301defa984bbdbe112b4763e093ed191750a0d914a78c1106b2d0fe703"
 dependencies = [
  "atty",
  "backtrace",
- "miette-derive",
+ "miette-derive 5.5.0",
  "once_cell",
  "owo-colors",
  "supports-color",
@@ -380,6 +432,17 @@ dependencies = [
  "textwrap",
  "thiserror",
  "unicode-width",
+]
+
+[[package]]
+name = "miette-derive"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b5bc45b761bcf1b5e6e6c4128cd93b84c218721a8d9b894aa0aff4ed180174c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,32 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
+name = "ahash"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -18,10 +44,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi 0.1.19",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "backtrace"
+version = "0.3.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233d376d6d185f2a3093e58f283f60f880315b6c60075b01f36b3b85154564ca"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
 
 [[package]]
 name = "bitflags"
@@ -114,7 +166,7 @@ dependencies = [
 
 [[package]]
 name = "gestures"
-version = "0.2.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -122,6 +174,7 @@ dependencies = [
  "input",
  "libc",
  "log",
+ "miette",
  "nix",
  "regex",
  "serde",
@@ -129,10 +182,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "gimli"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
 name = "heck"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -187,11 +275,17 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aae5bc6e2eb41c9def29a3e0f1306382807764b9b53112030eff57435667352d"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.2.6",
  "io-lifetimes",
  "rustix",
  "windows-sys",
 ]
+
+[[package]]
+name = "is_ci"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616cde7c720bb2bb5824a224687d8f77bfd38922027f01d825cd7453be5099fb"
 
 [[package]]
 name = "itoa"
@@ -269,6 +363,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "miette"
+version = "5.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4afd9b301defa984bbdbe112b4763e093ed191750a0d914a78c1106b2d0fe703"
+dependencies = [
+ "atty",
+ "backtrace",
+ "miette-derive",
+ "once_cell",
+ "owo-colors",
+ "supports-color",
+ "supports-hyperlinks",
+ "supports-unicode",
+ "terminal_size",
+ "textwrap",
+ "thiserror",
+ "unicode-width",
+]
+
+[[package]]
+name = "miette-derive"
+version = "5.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97c2401ab7ac5282ca5c8b518a87635b1a93762b0b90b9990c509888eeccba29"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
+dependencies = [
+ "adler",
+]
+
+[[package]]
 name = "nix"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -283,6 +417,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.30.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea86265d3d3dcb6a27fc51bd29a4bf387fae9d2986b823079d4986af253eb439"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -293,6 +436,12 @@ name = "os_str_bytes"
 version = "6.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
+
+[[package]]
+name = "owo-colors"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
 name = "pin-utils"
@@ -372,6 +521,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
+
+[[package]]
 name = "rustix"
 version = "0.36.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -422,10 +577,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "smawk"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f67ad224767faa3c7d8b6d91985b78e70a1324408abcb1cfcc2be4c06bc06043"
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "supports-color"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ba6faf2ca7ee42fdd458f4347ae0a9bd6bcc445ad7cb57ad82b383f18870d6f"
+dependencies = [
+ "atty",
+ "is_ci",
+]
+
+[[package]]
+name = "supports-hyperlinks"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "590b34f7c5f01ecc9d78dba4b3f445f31df750a67621cf31626f3b7441ce6406"
+dependencies = [
+ "atty",
+]
+
+[[package]]
+name = "supports-unicode"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8b945e45b417b125a8ec51f1b7df2f8df7920367700d1f98aedd21e5735f8b2"
+dependencies = [
+ "atty",
+]
 
 [[package]]
 name = "syn"
@@ -448,6 +637,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "terminal_size"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7b3e525a49ec206798b40326a44121291b530c963cfb01018f63e135bac543d"
+dependencies = [
+ "smawk",
+ "unicode-linebreak",
+ "unicode-width",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "udev"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -465,10 +695,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
 
 [[package]]
+name = "unicode-linebreak"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5faade31a542b8b35855fff6e8def199853b2da8da256da52f52f1316ee3137"
+dependencies = [
+ "hashbrown",
+ "regex",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
+
+[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "winapi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,12 +38,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.66"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
-
-[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -180,7 +174,6 @@ dependencies = [
 name = "gestures"
 version = "0.4.0"
 dependencies = [
- "anyhow",
  "clap",
  "env_logger",
  "input",
@@ -191,7 +184,6 @@ dependencies = [
  "nix",
  "regex",
  "serde",
- "serde-lexpr",
 ]
 
 [[package]]
@@ -301,12 +293,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "616cde7c720bb2bb5824a224687d8f77bfd38922027f01d825cd7453be5099fb"
 
 [[package]]
-name = "itoa"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
-
-[[package]]
 name = "knuffel"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -331,29 +317,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "lexpr"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ceee0b80e0043f17bf81130471e1b0975179af75fe657af45577d80e2698fe3b"
-dependencies = [
- "itoa",
- "lexpr-macros",
- "proc-macro-hack",
- "ryu",
-]
-
-[[package]]
-name = "lexpr-macros"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd627fb38e19c00d8d068618259205f7a91c91aeade5c15bc35dbca037bb1c35"
-dependencies = [
- "proc-macro-hack",
- "proc-macro2",
- "quote",
 ]
 
 [[package]]
@@ -543,12 +506,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-hack"
-version = "0.5.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -604,28 +561,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "ryu"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
-
-[[package]]
 name = "serde"
 version = "1.0.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d193d69bae983fc11a79df82342761dfbf28a99fc8d203dca4c3c1b590948965"
 dependencies = [
  "serde_derive",
-]
-
-[[package]]
-name = "serde-lexpr"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b305d32ef3ad5ebf721122b0b9aeecbf67e843e6fbafb6b5cefa4fb9dc3909f"
-dependencies = [
- "lexpr",
- "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,4 @@ anyhow = "1.0.66"
 regex = "1.7"
 log = "0.4.17"
 env_logger = "0.10.0"
+miette = { version = "5.5.0", features = ["fancy"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,4 @@ regex = "1.7"
 log = "0.4.17"
 env_logger = "0.10.0"
 miette = { version = "5.5.0", features = ["fancy"] }
+knuffel = "2.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,12 +9,10 @@ keywords = ["touchpad", "gestures", "libinput", "multitouch", "linux"]
 
 [dependencies]
 clap = { version = "4.0.26", features = ["derive"] }
-serde-lexpr = "0.1.2"
 serde = { version = "1.0", features = ["derive"] }
 input = "0.7"
 libc = "0.2"
 nix = {version = "0.25", features = ["poll"]}
-anyhow = "1.0.66"
 regex = "1.7"
 log = "0.4.17"
 env_logger = "0.10.0"

--- a/config.md
+++ b/config.md
@@ -1,52 +1,31 @@
 # Gestures configuration
 ## Location
-`$HOME/.config/gestures.conf`, `$HOME/.config/gestures/gestures.conf` and `$HOME/.gestures.conf`
-are the configuration locations. They are read in that order, stopping whenever the first one is
-encountered.
+The configuration is looked for at `$XDG_CONFIG_HOME/gestures.kdl` and then at
+`$XDG_CONFIG_HOME/gestures/gestures.kdl`. If `XDG_CONFIG_HOME` is not set, `$HOME/.config` is used
+instead.
+
 ## Format
-The configuration format is based on s-expressions.
-```lisp
-(
-  ; device specifies which touchpad device to use. If left empty, selection is automatic.
-  ; Currently HAS NO EFFECT
-  ; (device)
-  ; list of gestures. Available options are `swipe`, `pinch`, `hold` and `rotate`.
-  ; Only `swipe` and `pinch` are currently implemented, others are ignored.
-  ;
-  ; All fields shown are required
-  (gestures
-    (swipe
-      ; `direction`: can be N, S, E, W, NE, NW, SE, SW or any
-      (direction . N)
-      ; `fingers`: basically can be 3 or 4, because less than three libinput does not recognize
-      ; as a gesture, and AFAICT more than four are not counted
-      (fingers . 4)
-      ; `action`: command to execute on update event. Anything that works with `sh -c` should work here.
-      (update . (""))
-      ; `start`: command to execute on start event
-      (start . (""))
-      ; `end`: command to execute on end event
-      (end . ("rofi -show drun"))
-    )
-    (pinch
-      ; same as above
-      (fingers . 3)
-      ; `direction`: in or out or any
-      (direction . in)
-      ; same as above
-      (update . (""))
-      ; same as above
-      (start . (""))
-      ; same as above
-      (end . ("killall rofi"))
-    )
-    ; hold action
-    ; note that only oneshot is supported here
-    (hold
-      (fingers . 4)
-      (action . "rofi -show drun")
-    )
-  )
-)
-  
+The configuration format (since 0.5.0) uses [`kdl`](https://kdl.dev).
+```kdl
+// Swipe requires a direction and fingers field at least
+// direction can be one of "nw", "n", "ne", "w", "any", "e", "sw", "s", or "se"
+// fingers is the number of fingers used to trigger the action
+// start, update, and end are all optional. They are executed with `sh -c` and are executed when
+// the gesture is started, recieves an update event and ends.
+//
+// In all of the fields which execute a shell command, `delta_x`, `delta_y` and `scale` are replaced
+// with the delta in the x and y directions and the scale (movement farther apart or closer together)
+// of the gesture. If they are used for an action in which they do not make sense (e.g. using 
+// `scale` in the swipe gesture, 0.0 is used as the value.)
+//
+swipe direction="s" fingers=4 start="<command>" update="<command>" end="<command>"
+
+// pinch direction can be "in" or "out". Other fields are the same as for
+// the swipe gesture
+//
+pinch direction="out" fingers=3 start="<command>" update="<command>" end="<command>"
+
+// Hold only has one action, rather than start, end and update, because it does not
+// make much sense to update it.
+hold fingers=3 action="<command>"
 ```

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,14 +1,15 @@
 use std::{env, fs, path::Path};
 
 use miette::{bail, IntoDiagnostic, Result};
-use serde::{Deserialize, Serialize};
-use serde_lexpr::from_str;
+// use serde::{Deserialize, Serialize};
+use knuffel::{parse, Decode};
 
 use crate::gestures::Gesture;
 
-#[derive(Serialize, Deserialize, PartialEq, Debug, Default)]
+#[derive(Decode, PartialEq, Debug, Default)]
 pub struct Config {
-    pub device: Option<String>,
+    // pub device: Option<String>,
+    #[knuffel(children)]
     pub gestures: Vec<Gesture>,
 }
 
@@ -16,31 +17,25 @@ impl Config {
     pub fn read_from_file(file: &Path) -> Result<Self> {
         log::debug!("{:?}", &file);
         match fs::read_to_string(file) {
-            Ok(s) => Ok(from_str(&s).into_diagnostic()?),
+            // Ok(s) => Ok(parse::<Config>(file.to_str().unwrap(), &s).into_diagnostic()?),
+            Ok(s) => Ok(parse::<Config>(file.to_str().unwrap(), &s).unwrap()),
             _ => bail!("Could not read config file"),
         }
     }
 
     pub fn read_default_config() -> Result<Self> {
-        let home = env::var("HOME").into_diagnostic()?;
+        let config_home = env::var("XDG_CONFIG_HOME")
+            .unwrap_or_else(|_| format!("{}/.config", env::var("HOME").unwrap()));
 
-        log::debug!("{:?}", &home);
+        log::debug!("{:?}", &config_home);
 
-        let path = &format!("{home}/.config/gestures.conf");
-        if let Ok(s) = Self::read_from_file(Path::new(path)) {
-            return Ok(s);
+        for path in ["gestures.kdl", "gestures/gestures.kdl"] {
+            match Self::read_from_file(Path::new(&format!("{config_home}/{path}"))) {
+                Ok(s) => return Ok(s),
+                Err(e) => log::warn!("{}", e),
+            }
         }
 
-        let path = &format!("{home}/.config/gestures/gestures.conf");
-        if let Ok(s) = Self::read_from_file(Path::new(path)) {
-            return Ok(s);
-        }
-
-        let path = &format!("{home}/.gestures.conf");
-        if let Ok(s) = Self::read_from_file(Path::new(path)) {
-            return Ok(s);
-        }
-
-        bail!("could not find config file")
+        bail!("Could not find config file")
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,6 @@
 use std::{env, fs, path::Path};
 
-use anyhow::{bail, Result};
+use miette::{bail, IntoDiagnostic, Result};
 use serde::{Deserialize, Serialize};
 use serde_lexpr::from_str;
 
@@ -16,27 +16,27 @@ impl Config {
     pub fn read_from_file(file: &Path) -> Result<Self> {
         log::debug!("{:?}", &file);
         match fs::read_to_string(file) {
-            Ok(s) => Ok(from_str(&s)?),
+            Ok(s) => Ok(from_str(&s).into_diagnostic()?),
             _ => bail!("Could not read config file"),
         }
     }
 
     pub fn read_default_config() -> Result<Self> {
-        let home = env::var("HOME")?;
+        let home = env::var("HOME").into_diagnostic()?;
 
         log::debug!("{:?}", &home);
 
-        let path = &format!("{}/.config/gestures.conf", home);
+        let path = &format!("{home}/.config/gestures.conf");
         if let Ok(s) = Self::read_from_file(Path::new(path)) {
             return Ok(s);
         }
 
-        let path = &format!("{}/.config/gestures/gestures.conf", home);
+        let path = &format!("{home}/.config/gestures/gestures.conf");
         if let Ok(s) = Self::read_from_file(Path::new(path)) {
             return Ok(s);
         }
 
-        let path = &format!("{}/.gestures.conf", home);
+        let path = &format!("{home}/.gestures.conf");
         if let Ok(s) = Self::read_from_file(Path::new(path)) {
             return Ok(s);
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,8 +17,7 @@ impl Config {
     pub fn read_from_file(file: &Path) -> Result<Self> {
         log::debug!("{:?}", &file);
         match fs::read_to_string(file) {
-            // Ok(s) => Ok(parse::<Config>(file.to_str().unwrap(), &s).into_diagnostic()?),
-            Ok(s) => Ok(parse::<Config>(file.to_str().unwrap(), &s).unwrap()),
+            Ok(s) => Ok(parse::<Config>(file.to_str().unwrap(), &s).into_diagnostic()?),
             _ => bail!("Could not read config file"),
         }
     }

--- a/src/gestures.rs
+++ b/src/gestures.rs
@@ -5,7 +5,6 @@ use std::{
     rc::Rc,
 };
 
-use anyhow::{bail, Result};
 use input::{
     event::{
         gesture::{
@@ -17,6 +16,7 @@ use input::{
     DeviceCapability, Libinput, LibinputInterface,
 };
 use libc::{O_RDWR, O_WRONLY};
+use miette::{miette, Result};
 use nix::poll::{poll, PollFd, PollFlags};
 use serde::{Deserialize, Serialize};
 
@@ -174,7 +174,7 @@ impl EventHandler {
         if self.has_gesture_device(input) {
             Ok(())
         } else {
-            bail!("Could not find gesture device");
+            Err(miette!("Could not find gesture device"))
         }
     }
 

--- a/src/gestures.rs
+++ b/src/gestures.rs
@@ -18,7 +18,8 @@ use input::{
 use libc::{O_RDWR, O_WRONLY};
 use miette::{miette, Result};
 use nix::poll::{poll, PollFd, PollFlags};
-use serde::{Deserialize, Serialize};
+// use serde::{Deserialize, Serialize};
+use knuffel::{Decode, DecodeScalar};
 
 use crate::config::Config;
 use crate::utils::exec_command_from_string;
@@ -28,9 +29,8 @@ use crate::utils::exec_command_from_string;
 /// NW  N  NE
 /// W   C   E
 /// SW  S  SE
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(DecodeScalar, Debug, Clone, PartialEq, Eq)]
 pub enum Direction {
-    #[serde(rename = "any")]
     Any,
     N,
     S,
@@ -96,63 +96,77 @@ impl Direction {
 }
 
 /// Direction of pinch gestures
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
+#[derive(DecodeScalar, Debug, Clone, PartialEq, Eq)]
 pub enum InOut {
     In,
     Out,
     Any,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum Repeat {
-    Oneshot,
-    Continuous,
-}
+// #[derive(DecodeScalar, Debug, Clone, PartialEq, Eq)]
+// pub enum Repeat {
+//     Oneshot,
+//     Continuous,
+// }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
+#[derive(Decode, Debug, Clone, PartialEq)]
 pub enum Gesture {
     Swipe(Swipe),
     Pinch(Pinch),
     Hold(Hold),
-    Rotate(Rotate),
+    // Rotate(Rotate),
     None,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Decode, Debug, Clone, PartialEq, Eq)]
 pub struct Swipe {
+    #[knuffel(property)]
     pub direction: Direction,
+    #[knuffel(property)]
     pub fingers: i32,
+    #[knuffel(property)]
     pub update: Option<String>,
+    #[knuffel(property)]
     pub start: Option<String>,
+    #[knuffel(property)]
     pub end: Option<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Decode, Debug, Clone, PartialEq, Eq)]
 pub struct Pinch {
+    #[knuffel(property)]
     pub fingers: i32,
+    #[knuffel(property)]
     pub direction: InOut,
+    #[knuffel(property)]
     pub update: Option<String>,
+    #[knuffel(property)]
     pub start: Option<String>,
+    #[knuffel(property)]
     pub end: Option<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Decode, Debug, Clone, PartialEq, Eq)]
 pub struct Hold {
+    #[knuffel(property)]
     pub fingers: i32,
+    #[knuffel(property)]
     pub action: Option<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct Rotate {
-    pub scale: f64,
-    pub fingers: i32,
-    pub delta_angle: f64,
-    pub repeat: Repeat,
-    pub action: String,
-}
+// #[derive(Decode, Debug, Clone, PartialEq)]
+// pub struct Rotate {
+//     #[knuffel(property)]
+//     pub scale: f64,
+//     #[knuffel(property)]
+//     pub fingers: i32,
+//     #[knuffel(property)]
+//     pub delta_angle: f64,
+//     #[knuffel(property)]
+//     pub repeat: Repeat,
+//     #[knuffel(property)]
+//     pub action: String,
+// }
 
 #[derive(Debug)]
 pub struct EventHandler {

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,10 +7,10 @@ mod tests;
 
 use std::{path::PathBuf, rc::Rc};
 
-use anyhow::Result;
 use clap::Parser;
 use env_logger::Builder;
 use log::LevelFilter;
+use miette::Result;
 
 use crate::config::*;
 

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -8,7 +8,7 @@ fn test_config_default() {
     assert_eq!(
         c,
         Config {
-            device: None,
+            // device: None,
             gestures: vec![],
         }
     );

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,15 +1,19 @@
-use anyhow::Result;
+use miette::{IntoDiagnostic, Result};
 use regex::Regex;
 use std::process::Command;
 
 pub fn exec_command_from_string(args: &str, dx: f64, dy: f64, scale: f64) -> Result<()> {
-    let rx = Regex::new(r"[^\\]\$delta_x")?;
-    let ry = Regex::new(r"[^\\]\$delta_y")?;
-    let rs = Regex::new(r"[^\\]\$scale")?;
-    let args = ry.replace_all(args, format!(" {} ", dy));
-    let args = rx.replace_all(&args, format!(" {} ", dx));
-    let args = rs.replace_all(&args, format!(" {} ", scale));
+    let rx = Regex::new(r"[^\\]\$delta_x").into_diagnostic()?;
+    let ry = Regex::new(r"[^\\]\$delta_y").into_diagnostic()?;
+    let rs = Regex::new(r"[^\\]\$scale").into_diagnostic()?;
+    let args = ry.replace_all(args, format!(" {dy} "));
+    let args = rx.replace_all(&args, format!(" {dx} "));
+    let args = rs.replace_all(&args, format!(" {scale} "));
     log::debug!("{:?}", &args);
-    Command::new("sh").arg("-c").arg(&*args).spawn()?;
+    Command::new("sh")
+        .arg("-c")
+        .arg(&*args)
+        .spawn()
+        .into_diagnostic()?;
     Ok(())
 }


### PR DESCRIPTION
- Switch to `miette` for errors for better interop with `knuffel`
- Fix clippy suggestions for new format strings
- Switch to `kdl` config
- Improve config loading code